### PR TITLE
feat: headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,24 @@ func TestRoutes(t *testing.T) {
 
 The package provide a binary cli tool: `eskip-match`
 
+```
+NAME:
+   eskip-match - A command line tool that helps you test .eskip files routing matching logic
+
+USAGE:
+   eskip-match [global options] command [command options] [arguments...]
+
+COMMANDS:
+     test, t  Given a routes file and request attributes, checks a route matches
+     help, h  Shows a list of commands or help for one command
+
+GLOBAL OPTIONS:
+   --config FILE, -c FILE  Load configuration from FILE
+   --help, -h              show help
+   --version, -v           print the version
+
+```
+
 ### Commands
 
 ### Test

--- a/README.md
+++ b/README.md
@@ -129,13 +129,19 @@ Test if a request to path `/foo` using `GET` method matches a route:
 eskip-match test routes.eskip -p /foo -m GET
 ```
 
+Specifying headers:
+
+```bash
+eskip-match test routes.eskip -p /foo -H Accept=application/json -H Authorization="Bearer XXX"
+```
+
 Using **verbose output** might help when something doesn't seem to work as expected:
 
 ```bash
 eskip-match test routes.eskip -v -p /foo
 ```
 
-If your routes are using **custom filters** the tool must be informed via a **configuration file** like:
+If your routes are using **custom filters** the tool must be informed via a **configuration file** named `.eskip-match.yml`, eg:
 
 *.eskip-match.yml*
 ```yaml
@@ -144,16 +150,16 @@ customfilters:
   - myCustomFilter2
 ```
 
-And then run the command with `-c` flag:
-
 ```bash
-eskip-match -c .eskip-match.yml test routes.eskip -p /foo
+eskip-match test routes.eskip -p /foo
 ```
 
 > By default the tool will try to load `.eskip-match.yml` in the current working directory, but you can provide a custom location with `-c` global option, eg:
 ```bash
 eskip-match -c config.yml test routes.eskip -p /foo
 ```
+
+
 
 ## License
 

--- a/command/command_test.eskip
+++ b/command/command_test.eskip
@@ -1,1 +1,2 @@
 bar: Path("/bar") -> <shunt>;
+bar_header: Path("/bar") && Header("foo", "bar") -> <shunt>;

--- a/command/command_test.go
+++ b/command/command_test.go
@@ -12,25 +12,41 @@ func TestApp(t *testing.T) {
 	}
 
 	scenarios := []struct {
-		Args     []string
-		ExpError bool
+		title    string
+		args     []string
+		expError bool
 	}{
 		{
-			Args: []string{"eskip-match", "test", "command_test.eskip", "-p", "/bar"},
+			title: "match",
+			args:  []string{"eskip-match", "test", "command_test.eskip", "-p", "/bar"},
 		},
 		{
-			ExpError: true,
-			Args:     []string{"eskip-match", "test", "command_test.eskip", "-p", "/foofoo"},
+			title:    "dont-match",
+			expError: true,
+			args:     []string{"eskip-match", "test", "command_test.eskip", "-p", "/foofoo"},
+		},
+		{
+			title: "headers",
+			args: []string{
+				"eskip-match",
+				"test",
+				"command_test.eskip",
+				"-p", "/bar",
+				"-H",
+				"foo=bar",
+				"-H",
+				"bar=foo",
+			},
 		},
 	}
 
 	for _, s := range scenarios {
-		t.Run(strings.Join(s.Args[:], " "), func(t *testing.T) {
-			err := app.Run(s.Args)
-			if s.ExpError && err == nil {
+		t.Run(strings.Join(s.args[:], ", "), func(t *testing.T) {
+			err := app.Run(s.args)
+			if s.expError && err == nil {
 				t.Error("expecting error but got nil")
 			}
-			if s.ExpError == false && err != nil {
+			if s.expError == false && err != nil {
 				t.Error("expecting match but got error", err)
 			}
 		})

--- a/matcher/matcher_test.eskip
+++ b/matcher/matcher_test.eskip
@@ -1,5 +1,6 @@
 bar: Path("/bar") -> <shunt>;
 foo: PathSubtree("/foo") -> <shunt>;
 foo_get: Method("GET") && Path("/foo") -> <shunt>;
+foo_header: Method("GET") && Path("/foo") && Header("Accept", "application/json") -> <shunt>;
 query_param: QueryParam("q") -> <shunt>;
 customfilter: Path("/customfilter") -> customfilter() -> <shunt>;

--- a/matcher/matcher_test.go
+++ b/matcher/matcher_test.go
@@ -107,6 +107,17 @@ func TestRoutes(t *testing.T) {
 			},
 		},
 		{
+			expectedRouteID: "foo_header",
+			reqAttributes: []*RequestAttributes{
+				{
+					Path: "/foo",
+					Headers: map[string]string{
+						"Accept": "application/json",
+					},
+				},
+			},
+		},
+		{
 			expectedRouteID: "customfilter",
 			reqAttributes: []*RequestAttributes{
 				{


### PR DESCRIPTION
Specify headers:

```
eskip-match t routes.eskip -p /path -H Accept=application/json -H Authorization="Bearer XXX"
```