### PR TITLE
chore: don't use go get

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ before_install:
 
 script:
   - make test.coverage
+  - make build
 
 after_success:
   - bash <(curl -s https://codecov.io/bash)

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,6 @@ GOMODULE   ?= GO111MODULE=on
 default: install test build
 
 install:
-	$(GOMODULE) go get -t -v ./...
 	$(GOMODULE) go get github.com/mitchellh/gox
 
 test:


### PR DESCRIPTION
chore: don't use `go get` to install deps on travis, use just `go mod` 